### PR TITLE
fix(docs): minor formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,16 @@ A terminal-based user interface (TUI) application for viewing AWS Lambda functio
 
 1. Clone the repository:
 
+```shell
 git clone https://github.com/resola-ai/rust-aws-tui
 cd rust-aws-tui
+```
 
 2. Build and install:
 
+```
 cargo install --path .
+```
 
 ## Usage
 


### PR DESCRIPTION
fixes formatting where previously the cd command was shown on the same line as the git clone.